### PR TITLE
Add Readwise sync button to All Highlights page

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -344,6 +344,7 @@ async def all_highlights(
             "note": highlight.note,
             "page_number": highlight.page_number,
             "created_at": highlight.created_at,
+            "synced_at": highlight.synced_at,
             "book_id": book.id,
             "book_title": book.title,
             "book_author": book.author,

--- a/app/templates/all_highlights.html
+++ b/app/templates/all_highlights.html
@@ -33,12 +33,31 @@
                 {% endif %}
                 <span>{{ highlight.created_at.strftime('%b %d, %Y') }}</span>
             </div>
-            <form action="/highlights/{{ highlight.id }}/delete" method="post"
-                  onsubmit="return confirm('Delete this highlight?');">
-                <button type="submit" class="text-red-600 hover:text-red-700">
-                    Delete
+            <div class="flex items-center gap-3">
+                {% if highlight.synced_at %}
+                <span class="inline-flex items-center gap-1 text-green-600 px-2 py-1 bg-green-50 rounded" title="Synced to Readwise on {{ highlight.synced_at.strftime('%b %d, %Y') }}">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                    </svg>
+                    Synced
+                </span>
+                {% else %}
+                <button id="sync-btn-{{ highlight.id }}"
+                        onclick="syncHighlightToReadwise({{ highlight.id }})"
+                        class="inline-flex items-center gap-1 text-amber-700 px-2 py-1 bg-amber-50 rounded hover:bg-amber-100 transition">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" />
+                    </svg>
+                    <span id="sync-btn-text-{{ highlight.id }}">Sync</span>
                 </button>
-            </form>
+                {% endif %}
+                <form action="/highlights/{{ highlight.id }}/delete" method="post"
+                      onsubmit="return confirm('Delete this highlight?');">
+                    <button type="submit" class="text-red-600 hover:text-red-700">
+                        Delete
+                    </button>
+                </form>
+            </div>
         </div>
     </div>
     {% endfor %}
@@ -59,4 +78,45 @@
     </a>
 </div>
 {% endif %}
+
+<script>
+async function syncHighlightToReadwise(highlightId) {
+    const btn = document.getElementById(`sync-btn-${highlightId}`);
+    const btnText = document.getElementById(`sync-btn-text-${highlightId}`);
+
+    btn.disabled = true;
+    btnText.textContent = 'Syncing...';
+
+    try {
+        const response = await fetch(`/api/readwise/sync/${highlightId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.success) {
+            // Replace button with synced indicator
+            btn.outerHTML = `
+                <span class="inline-flex items-center gap-1 text-green-600 px-2 py-1 bg-green-50 rounded" title="Synced to Readwise">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
+                    </svg>
+                    Synced
+                </span>
+            `;
+        } else {
+            alert(data.detail || data.error || 'Failed to sync. Please configure your Readwise API token.');
+            btnText.textContent = 'Sync';
+            btn.disabled = false;
+        }
+    } catch (error) {
+        alert('Network error. Please try again.');
+        btnText.textContent = 'Sync';
+        btn.disabled = false;
+    }
+}
+</script>
 {% endblock %}

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -168,6 +168,16 @@ class TestAllHighlightsView:
         assert sample_highlight.text in response.text
         assert sample_book.title in response.text
 
+    async def test_all_highlights_shows_sync_button(
+        self, client: AsyncClient, sample_book, sample_highlight
+    ):
+        """Test that sync button appears for unsynced highlights."""
+        response = await client.get("/highlights")
+        assert response.status_code == 200
+        # Check for sync button (unsynced highlight)
+        assert f"sync-btn-{sample_highlight.id}" in response.text
+        assert "syncHighlightToReadwise" in response.text
+
 
 class TestDeleteHighlightView:
     """Tests for highlight deletion."""


### PR DESCRIPTION
## Summary
- Add sync button and synced indicator to the All Highlights page
- Match the UI/UX of the Book Detail page

## Changes
- Added `synced_at` field to the view data for All Highlights
- Added per-highlight sync button for unsynced highlights
- Added green "Synced" badge for synced highlights
- Added JavaScript for async sync with loading state

## Test Plan
- [x] All 111 tests pass
- [x] New test verifies sync button appears on page
- [x] Visual verification: sync buttons display correctly

Closes #13

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)