### PR TITLE
feat: Make Extract and Manual sections collapsible on Add Highlight page

### DIFF
--- a/app/templates/add_highlight.html
+++ b/app/templates/add_highlight.html
@@ -21,103 +21,135 @@
 </div>
 {% endif %}
 
-<!-- Image extraction form -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-6">
-    <h2 class="font-semibold text-gray-900 mb-3">Extract from Image</h2>
-    <p class="text-sm text-gray-600 mb-4">
-        Take a photo of a book page and describe which text to extract.
-    </p>
-    <form id="extract-form" action="/books/{{ book.id }}/extract" method="post" enctype="multipart/form-data" class="space-y-4">
+<!-- Image extraction form (collapsible) -->
+<div class="bg-white rounded-xl shadow-sm border border-gray-200 mb-6">
+    <button type="button"
+            onclick="toggleSection('extract-section', 'extract-chevron')"
+            class="w-full p-4 flex items-center justify-between text-left">
         <div>
-            <label for="image" class="block text-sm font-medium text-gray-700 mb-1">Photo of the page</label>
-            <input type="file"
-                   id="image"
-                   name="image"
-                   accept="image/*"
-                   capture="environment"
-                   required
-                   class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100">
-        </div>
-        <div>
-            <label for="instructions" class="block text-sm font-medium text-gray-700 mb-1">What to extract</label>
-            <textarea id="instructions"
-                      name="instructions"
-                      rows="2"
-                      placeholder="e.g., 'the highlighted text' or 'the sentence about freedom' or 'first paragraph'"
-                      required
-                      class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none">{{ instructions if instructions else '' }}</textarea>
-            <p class="text-xs text-gray-500 mt-1">
-                Examples: "the highlighted passage", "sentence containing 'love'", "the quote at the top"
+            <h2 class="font-semibold text-gray-900">Extract from Image</h2>
+            <p class="text-sm text-gray-600 mt-1">
+                Take a photo of a book page and describe which text to extract.
             </p>
         </div>
-        <button type="submit"
-                id="extract-btn"
-                class="w-full bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition flex items-center justify-center gap-2">
-            <svg id="extract-icon" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
-            </svg>
-            <!-- Loading spinner (hidden by default) -->
-            <svg id="extract-spinner" class="hidden animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
-            <span id="extract-btn-text">Extract Text</span>
-        </button>
-    </form>
+        <svg id="extract-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 transition-transform {{ 'rotate-180' if not extracted_text else '' }}" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+    </button>
+    <div id="extract-section" class="{{ 'hidden' if extracted_text else '' }}">
+        <div class="px-4 pb-4">
+            <form id="extract-form" action="/books/{{ book.id }}/extract" method="post" enctype="multipart/form-data" class="space-y-4">
+                <div>
+                    <label for="image" class="block text-sm font-medium text-gray-700 mb-1">Photo of the page</label>
+                    <input type="file"
+                           id="image"
+                           name="image"
+                           accept="image/*"
+                           capture="environment"
+                           required
+                           class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100">
+                </div>
+                <div>
+                    <label for="instructions" class="block text-sm font-medium text-gray-700 mb-1">What to extract</label>
+                    <textarea id="instructions"
+                              name="instructions"
+                              rows="2"
+                              placeholder="e.g., 'the highlighted text' or 'the sentence about freedom' or 'first paragraph'"
+                              required
+                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none">{{ instructions if instructions else '' }}</textarea>
+                    <p class="text-xs text-gray-500 mt-1">
+                        Examples: "the highlighted passage", "sentence containing 'love'", "the quote at the top"
+                    </p>
+                </div>
+                <button type="submit"
+                        id="extract-btn"
+                        class="w-full bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition flex items-center justify-center gap-2">
+                    <svg id="extract-icon" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
+                    </svg>
+                    <!-- Loading spinner (hidden by default) -->
+                    <svg id="extract-spinner" class="hidden animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    <span id="extract-btn-text">Extract Text</span>
+                </button>
+            </form>
+        </div>
+    </div>
 </div>
 
-<!-- Save highlight form -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-    <h2 class="font-semibold text-gray-900 mb-3">
-        {% if extracted_text %}Extracted Text{% else %}Enter Manually{% endif %}
-    </h2>
-
-    {% if confidence %}
-    <p class="text-sm mb-3">
-        <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
-            {% if confidence == 'high' %}bg-green-100 text-green-800
-            {% elif confidence == 'medium' %}bg-yellow-100 text-yellow-800
-            {% else %}bg-red-100 text-red-800{% endif %}">
-            Confidence: {{ confidence }}
-        </span>
-    </p>
-    {% endif %}
-
-    <form action="/books/{{ book.id }}/highlights/create" method="post" class="space-y-4">
+<!-- Save highlight form (collapsible) -->
+<div class="bg-white rounded-xl shadow-sm border border-gray-200">
+    <button type="button"
+            onclick="toggleSection('manual-section', 'manual-chevron')"
+            class="w-full p-4 flex items-center justify-between text-left">
         <div>
-            <label for="text" class="block text-sm font-medium text-gray-700 mb-1">Highlight text *</label>
-            <textarea id="text"
-                      name="text"
-                      rows="5"
-                      required
-                      placeholder="Type or paste the highlight text..."
-                      class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none">{{ extracted_text }}</textarea>
+            <h2 class="font-semibold text-gray-900">
+                {% if extracted_text %}Extracted Text{% else %}Enter Manually{% endif %}
+            </h2>
+            {% if confidence %}
+            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium mt-1
+                {% if confidence == 'high' %}bg-green-100 text-green-800
+                {% elif confidence == 'medium' %}bg-yellow-100 text-yellow-800
+                {% else %}bg-red-100 text-red-800{% endif %}">
+                Confidence: {{ confidence }}
+            </span>
+            {% else %}
+            <p class="text-sm text-gray-600 mt-1">Type or paste your highlight text directly.</p>
+            {% endif %}
         </div>
-        <div>
-            <label for="page_number" class="block text-sm font-medium text-gray-700 mb-1">Page number (optional)</label>
-            <input type="text"
-                   id="page_number"
-                   name="page_number"
-                   value="{{ page_number }}"
-                   placeholder="e.g., 42 or 42-43"
-                   class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+        <svg id="manual-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 transition-transform rotate-180" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+    </button>
+    <div id="manual-section">
+        <div class="px-4 pb-4">
+            <form action="/books/{{ book.id }}/highlights/create" method="post" class="space-y-4">
+                <div>
+                    <label for="text" class="block text-sm font-medium text-gray-700 mb-1">Highlight text *</label>
+                    <textarea id="text"
+                              name="text"
+                              rows="5"
+                              required
+                              placeholder="Type or paste the highlight text..."
+                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none">{{ extracted_text }}</textarea>
+                </div>
+                <div>
+                    <label for="page_number" class="block text-sm font-medium text-gray-700 mb-1">Page number (optional)</label>
+                    <input type="text"
+                           id="page_number"
+                           name="page_number"
+                           value="{{ page_number }}"
+                           placeholder="e.g., 42 or 42-43"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+                </div>
+                <div>
+                    <label for="note" class="block text-sm font-medium text-gray-700 mb-1">Your note (optional)</label>
+                    <textarea id="note"
+                              name="note"
+                              rows="2"
+                              placeholder="Add your thoughts about this highlight..."
+                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none"></textarea>
+                </div>
+                <button type="submit"
+                        class="w-full bg-green-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-green-700 transition">
+                    Save Highlight
+                </button>
+            </form>
         </div>
-        <div>
-            <label for="note" class="block text-sm font-medium text-gray-700 mb-1">Your note (optional)</label>
-            <textarea id="note"
-                      name="note"
-                      rows="2"
-                      placeholder="Add your thoughts about this highlight..."
-                      class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none"></textarea>
-        </div>
-        <button type="submit"
-                class="w-full bg-green-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-green-700 transition">
-            Save Highlight
-        </button>
-    </form>
+    </div>
 </div>
 
 <script>
+function toggleSection(sectionId, chevronId) {
+    const section = document.getElementById(sectionId);
+    const chevron = document.getElementById(chevronId);
+
+    section.classList.toggle('hidden');
+    chevron.classList.toggle('rotate-180');
+}
+
 document.getElementById('extract-form').addEventListener('submit', function() {
     const btn = document.getElementById('extract-btn');
     const icon = document.getElementById('extract-icon');

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -124,6 +124,22 @@ class TestAddHighlightView:
         assert "Extracting..." in response.text
         assert "animate-spin" in response.text
 
+    async def test_add_highlight_page_has_collapsible_sections(
+        self, client: AsyncClient, sample_book
+    ):
+        """Test add highlight page has collapsible accordion sections."""
+        response = await client.get(f"/books/{sample_book.id}/add-highlight")
+        assert response.status_code == 200
+        # Check for collapsible section elements
+        assert "toggleSection" in response.text
+        assert "extract-section" in response.text
+        assert "extract-chevron" in response.text
+        assert "manual-section" in response.text
+        assert "manual-chevron" in response.text
+        # Check for section headers
+        assert "Extract from Image" in response.text
+        assert "Enter Manually" in response.text
+
     async def test_add_highlight_page_not_found(self, client: AsyncClient):
         """Test add highlight page for non-existent book."""
         response = await client.get("/books/99999/add-highlight")


### PR DESCRIPTION
## Summary
- Add accordion-style collapsible sections to the Add Highlight page
- Extract from Image section starts expanded, collapses automatically after extraction
- Enter Manually section always stays visible to display extracted text or allow direct entry
- Chevron icons with rotation animation indicate collapse state

## Test plan
- [x] Verify Add Highlight page renders with collapsible sections
- [x] Check that Extract section collapses when text is extracted
- [x] Verify Manual section stays expanded to show extracted text
- [x] Test clicking section headers toggles visibility
- [x] All existing tests pass (113 tests)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)