### PR TITLE
feat: Add HTTPS support for local development and Tailscale access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ htmlcov/
 *.sqlite
 *.sqlite3
 
+# SSL Certificates (local development)
+certs/
+
 # Uploads (temporary)
 uploads/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,35 @@ When adding new UI features:
 - Use CSS selectors or text-based locators (e.g., `page.locator("text=Save Highlight")`)
 - Test at multiple viewport sizes for responsive design
 
+## HTTPS Setup
+
+For local development or accessing over Tailscale, you may need HTTPS to avoid browser security warnings on form submissions.
+
+### Using Self-Signed Certificates
+
+1. **Generate certificates**:
+   ```bash
+   just gen-cert localhost
+   # Or for Tailscale access:
+   just gen-cert your-machine.tailnet-name.ts.net
+   ```
+
+2. **Start the server with HTTPS**:
+   ```bash
+   just dev-https
+   # Or for production:
+   just serve-https
+   ```
+
+3. **Accept the certificate** in your browser (self-signed certificates will show a warning).
+
+### Alternative: Tailscale HTTPS
+
+If using Tailscale, you can use Tailscale's built-in HTTPS feature:
+1. Enable HTTPS in your Tailscale admin console
+2. Access via `https://your-machine.tailnet-name.ts.net`
+3. Tailscale will handle certificate provisioning automatically
+
 ## Pull Request Workflow
 
 1. Create a feature branch from main

--- a/Justfile
+++ b/Justfile
@@ -45,10 +45,32 @@ ci: lint format-check type test
 install:
     uv sync --dev
 
-# Start development server
+# Start development server (HTTP)
 dev:
     uv run uvicorn app.main:app --host 0.0.0.0 --port 18742 --reload
+
+# Start development server with HTTPS (requires certs)
+dev-https:
+    @if [ ! -f certs/cert.pem ] || [ ! -f certs/key.pem ]; then \
+        echo "Error: SSL certificates not found."; \
+        echo "Run 'just gen-cert' to generate self-signed certificates."; \
+        exit 1; \
+    fi
+    uv run uvicorn app.main:app --host 0.0.0.0 --port 18742 --reload --ssl-keyfile=certs/key.pem --ssl-certfile=certs/cert.pem
+
+# Generate self-signed SSL certificates for local HTTPS
+gen-cert domain="localhost":
+    ./scripts/generate_cert.sh {{domain}}
 
 # Start production server
 serve:
     uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+
+# Start production server with HTTPS
+serve-https:
+    @if [ ! -f certs/cert.pem ] || [ ! -f certs/key.pem ]; then \
+        echo "Error: SSL certificates not found."; \
+        echo "Run 'just gen-cert' to generate certificates."; \
+        exit 1; \
+    fi
+    uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --ssl-keyfile=certs/key.pem --ssl-certfile=certs/cert.pem

--- a/scripts/generate_cert.sh
+++ b/scripts/generate_cert.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Generate self-signed SSL certificate for local HTTPS development
+# Usage: ./scripts/generate_cert.sh [domain]
+
+set -e
+
+DOMAIN="${1:-localhost}"
+CERT_DIR="certs"
+
+# Create certs directory if it doesn't exist
+mkdir -p "$CERT_DIR"
+
+echo "Generating self-signed certificate for: $DOMAIN"
+
+# Generate private key and self-signed certificate
+openssl req -x509 -newkey rsa:4096 \
+    -keyout "$CERT_DIR/key.pem" \
+    -out "$CERT_DIR/cert.pem" \
+    -days 365 \
+    -nodes \
+    -subj "/CN=$DOMAIN" \
+    -addext "subjectAltName=DNS:$DOMAIN,DNS:localhost,IP:127.0.0.1"
+
+echo ""
+echo "Certificate generated successfully!"
+echo "  Certificate: $CERT_DIR/cert.pem"
+echo "  Private key: $CERT_DIR/key.pem"
+echo ""
+echo "To start the server with HTTPS:"
+echo "  just dev-https"
+echo ""
+echo "Note: Browsers will show a warning for self-signed certificates."
+echo "You'll need to accept the certificate to proceed."


### PR DESCRIPTION
## Summary
- Add `scripts/generate_cert.sh` to generate self-signed SSL certificates
- Add Justfile commands for HTTPS server:
  - `just gen-cert [domain]` - Generate self-signed certificates
  - `just dev-https` - Start dev server with HTTPS
  - `just serve-https` - Start production server with HTTPS
- Update `.gitignore` to exclude `certs/` directory
- Document HTTPS setup in CLAUDE.md (self-signed certs + Tailscale options)

## Usage

```bash
# Generate certificates
just gen-cert localhost
# Or for Tailscale:
just gen-cert your-machine.tailnet-name.ts.net

# Start with HTTPS
just dev-https
```

## Test plan
- [x] All existing tests pass (121 tests)
- [x] Certificate generation script works
- [x] HTTPS commands added to Justfile
- [ ] Manual test: Generate cert and start with `just dev-https`

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)