### PR TITLE
feat: Add dark mode with system preference detection

### DIFF
--- a/app/templates/add_book.html
+++ b/app/templates/add_book.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="mb-6">
-    <a href="/" class="text-primary-600 hover:text-primary-700 flex items-center gap-1 text-sm">
+    <a href="/" class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 flex items-center gap-1 text-sm">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd" />
         </svg>
@@ -12,26 +12,26 @@
     </a>
 </div>
 
-<h1 class="text-2xl font-bold text-gray-900 mb-6">Add a Book</h1>
+<h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">Add a Book</h1>
 
 {% if error_message %}
-<div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+<div class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg mb-6">
     {{ error_message }}
 </div>
 {% endif %}
 
 <!-- Scan Cover/Barcode (collapsible) -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200 mb-6">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 mb-6">
     <button type="button"
             onclick="toggleSection('scan-section', 'scan-chevron')"
             class="w-full p-4 flex items-center justify-between text-left">
         <div>
-            <h2 class="font-semibold text-gray-900">Scan Cover or Barcode</h2>
-            <p class="text-sm text-gray-600 mt-1">
+            <h2 class="font-semibold text-gray-900 dark:text-white">Scan Cover or Barcode</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
                 Take a photo of the book's barcode or cover to auto-lookup.
             </p>
         </div>
-        <svg id="scan-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 transition-transform {{ 'rotate-180' if extracted_isbn else '' }}" viewBox="0 0 20 20" fill="currentColor">
+        <svg id="scan-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform {{ 'rotate-180' if extracted_isbn else '' }}" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
         </svg>
     </button>
@@ -39,15 +39,15 @@
         <div class="px-4 pb-4">
             <form id="scan-form" action="/books/scan-isbn" method="post" enctype="multipart/form-data" class="space-y-4">
                 <div>
-                    <label for="image" class="block text-sm font-medium text-gray-700 mb-1">Photo of cover or barcode</label>
+                    <label for="image" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Photo of cover or barcode</label>
                     <input type="file"
                            id="image"
                            name="image"
                            accept="image/*"
                            capture="environment"
                            required
-                           class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100">
-                    <p class="text-xs text-gray-500 mt-1">
+                           class="w-full text-sm text-gray-500 dark:text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 dark:file:bg-primary-900/50 file:text-primary-700 dark:file:text-primary-300 hover:file:bg-primary-100 dark:hover:file:bg-primary-900/70">
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                         Best results: photograph the barcode on the back cover
                     </p>
                 </div>
@@ -72,16 +72,16 @@
 
 {% if extracted_isbn %}
 <!-- Extracted ISBN indicator -->
-<div class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg mb-6 flex items-center gap-2">
+<div class="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-400 px-4 py-3 rounded-lg mb-6 flex items-center gap-2">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
     </svg>
     <span>Found ISBN: <strong>{{ extracted_isbn }}</strong></span>
     {% if isbn_confidence %}
     <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
-        {% if isbn_confidence == 'high' %}bg-green-100 text-green-800
-        {% elif isbn_confidence == 'medium' %}bg-yellow-100 text-yellow-800
-        {% else %}bg-red-100 text-red-800{% endif %}">
+        {% if isbn_confidence == 'high' %}bg-green-100 dark:bg-green-800/50 text-green-800 dark:text-green-300
+        {% elif isbn_confidence == 'medium' %}bg-yellow-100 dark:bg-yellow-800/50 text-yellow-800 dark:text-yellow-300
+        {% else %}bg-red-100 dark:bg-red-800/50 text-red-800 dark:text-red-300{% endif %}">
         {{ isbn_confidence }}
     </span>
     {% endif %}
@@ -89,17 +89,17 @@
 {% endif %}
 
 <!-- Search form (collapsible) -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200 mb-6">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 mb-6">
     <button type="button"
             onclick="toggleSection('search-section', 'search-chevron')"
             class="w-full p-4 flex items-center justify-between text-left">
         <div>
-            <h2 class="font-semibold text-gray-900">Search for a Book</h2>
-            <p class="text-sm text-gray-600 mt-1">
+            <h2 class="font-semibold text-gray-900 dark:text-white">Search for a Book</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
                 Search by title, author, or ISBN.
             </p>
         </div>
-        <svg id="search-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 transition-transform rotate-180" viewBox="0 0 20 20" fill="currentColor">
+        <svg id="search-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform rotate-180" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
         </svg>
     </button>
@@ -110,7 +110,7 @@
                        name="query"
                        value="{{ query }}"
                        placeholder="Search by title, author, or ISBN..."
-                       class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+                       class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500">
                 <button type="submit"
                         class="bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition">
                     Search
@@ -122,12 +122,12 @@
 
 {% if search_results is not none %}
 <!-- Search results -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-6">
-    <h2 class="font-semibold text-gray-900 mb-3">Search Results</h2>
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-6">
+    <h2 class="font-semibold text-gray-900 dark:text-white mb-3">Search Results</h2>
     {% if search_results %}
     <div class="space-y-3">
         {% for result in search_results %}
-        <form action="/books/create" method="post" class="border-b border-gray-100 last:border-b-0 pb-3 last:pb-0">
+        <form action="/books/create" method="post" class="border-b border-gray-100 dark:border-gray-700 last:border-b-0 pb-3 last:pb-0">
             <input type="hidden" name="title" value="{{ result.title }}">
             <input type="hidden" name="author" value="{{ result.author }}">
             <input type="hidden" name="isbn" value="{{ result.isbn or '' }}">
@@ -135,11 +135,11 @@
 
             <div class="flex gap-3">
                 <!-- Cover thumbnail -->
-                <div class="w-12 h-16 flex-shrink-0 bg-gray-200 rounded overflow-hidden">
+                <div class="w-12 h-16 flex-shrink-0 bg-gray-200 dark:bg-gray-700 rounded overflow-hidden">
                     {% if result.cover_url %}
                     <img src="{{ result.cover_url }}" alt="{{ result.title }}" class="w-full h-full object-cover">
                     {% else %}
-                    <div class="w-full h-full flex items-center justify-center text-gray-400">
+                    <div class="w-full h-full flex items-center justify-center text-gray-400 dark:text-gray-500">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                         </svg>
@@ -149,13 +149,13 @@
 
                 <!-- Book info -->
                 <div class="flex-1 min-w-0">
-                    <h3 class="font-medium text-gray-900 truncate">{{ result.title }}</h3>
-                    <p class="text-sm text-gray-600 truncate">{{ result.author }}</p>
+                    <h3 class="font-medium text-gray-900 dark:text-white truncate">{{ result.title }}</h3>
+                    <p class="text-sm text-gray-600 dark:text-gray-400 truncate">{{ result.author }}</p>
                 </div>
 
                 <!-- Add button -->
                 <button type="submit"
-                        class="flex-shrink-0 bg-primary-100 text-primary-700 px-3 py-1 rounded-lg text-sm font-medium hover:bg-primary-200 transition self-center">
+                        class="flex-shrink-0 bg-primary-100 dark:bg-primary-900/50 text-primary-700 dark:text-primary-300 px-3 py-1 rounded-lg text-sm font-medium hover:bg-primary-200 dark:hover:bg-primary-900/70 transition self-center">
                     Add
                 </button>
             </div>
@@ -163,23 +163,23 @@
         {% endfor %}
     </div>
     {% else %}
-    <p class="text-gray-600 text-center py-4">No books found. Try a different search or add manually below.</p>
+    <p class="text-gray-600 dark:text-gray-400 text-center py-4">No books found. Try a different search or add manually below.</p>
     {% endif %}
 </div>
 {% endif %}
 
 <!-- Manual entry form (collapsible) -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
     <button type="button"
             onclick="toggleSection('manual-section', 'manual-chevron')"
             class="w-full p-4 flex items-center justify-between text-left">
         <div>
-            <h2 class="font-semibold text-gray-900">Add Manually</h2>
-            <p class="text-sm text-gray-600 mt-1">
+            <h2 class="font-semibold text-gray-900 dark:text-white">Add Manually</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
                 Enter book details directly.
             </p>
         </div>
-        <svg id="manual-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 transition-transform" viewBox="0 0 20 20" fill="currentColor">
+        <svg id="manual-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
         </svg>
     </button>
@@ -187,35 +187,35 @@
         <div class="px-4 pb-4">
             <form action="/books/create" method="post" class="space-y-4">
                 <div>
-                    <label for="title" class="block text-sm font-medium text-gray-700 mb-1">Title *</label>
+                    <label for="title" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Title *</label>
                     <input type="text"
                            id="title"
                            name="title"
                            required
-                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+                           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
                 </div>
                 <div>
-                    <label for="author" class="block text-sm font-medium text-gray-700 mb-1">Author *</label>
+                    <label for="author" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Author *</label>
                     <input type="text"
                            id="author"
                            name="author"
                            required
-                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+                           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
                 </div>
                 <div>
-                    <label for="isbn" class="block text-sm font-medium text-gray-700 mb-1">ISBN (optional)</label>
+                    <label for="isbn" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">ISBN (optional)</label>
                     <input type="text"
                            id="isbn"
                            name="isbn"
-                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+                           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
                 </div>
                 <div>
-                    <label for="cover_url" class="block text-sm font-medium text-gray-700 mb-1">Cover Image URL (optional)</label>
+                    <label for="cover_url" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Cover Image URL (optional)</label>
                     <input type="url"
                            id="cover_url"
                            name="cover_url"
                            placeholder="https://..."
-                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+                           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500">
                 </div>
                 <button type="submit"
                         class="w-full bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition">

--- a/app/templates/add_highlight.html
+++ b/app/templates/add_highlight.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="mb-6">
-    <a href="/books/{{ book.id }}" class="text-primary-600 hover:text-primary-700 flex items-center gap-1 text-sm">
+    <a href="/books/{{ book.id }}" class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 flex items-center gap-1 text-sm">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd" />
         </svg>
@@ -12,27 +12,27 @@
     </a>
 </div>
 
-<h1 class="text-2xl font-bold text-gray-900 mb-2">Add Highlight</h1>
-<p class="text-gray-600 mb-6">{{ book.title }} by {{ book.author }}</p>
+<h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-2">Add Highlight</h1>
+<p class="text-gray-600 dark:text-gray-400 mb-6">{{ book.title }} by {{ book.author }}</p>
 
 {% if error_message %}
-<div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+<div class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 px-4 py-3 rounded-lg mb-6">
     {{ error_message }}
 </div>
 {% endif %}
 
 <!-- Image extraction form (collapsible) -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200 mb-6">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 mb-6">
     <button type="button"
             onclick="toggleSection('extract-section', 'extract-chevron')"
             class="w-full p-4 flex items-center justify-between text-left">
         <div>
-            <h2 class="font-semibold text-gray-900">Extract from Image</h2>
-            <p class="text-sm text-gray-600 mt-1">
+            <h2 class="font-semibold text-gray-900 dark:text-white">Extract from Image</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
                 Take a photo of a book page and describe which text to extract.
             </p>
         </div>
-        <svg id="extract-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 transition-transform {{ 'rotate-180' if not extracted_text else '' }}" viewBox="0 0 20 20" fill="currentColor">
+        <svg id="extract-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform {{ 'rotate-180' if not extracted_text else '' }}" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
         </svg>
     </button>
@@ -40,24 +40,24 @@
         <div class="px-4 pb-4">
             <form id="extract-form" action="/books/{{ book.id }}/extract" method="post" enctype="multipart/form-data" class="space-y-4">
                 <div>
-                    <label for="image" class="block text-sm font-medium text-gray-700 mb-1">Photo of the page</label>
+                    <label for="image" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Photo of the page</label>
                     <input type="file"
                            id="image"
                            name="image"
                            accept="image/*"
                            capture="environment"
                            required
-                           class="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100">
+                           class="w-full text-sm text-gray-500 dark:text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 dark:file:bg-primary-900/50 file:text-primary-700 dark:file:text-primary-300 hover:file:bg-primary-100 dark:hover:file:bg-primary-900/70">
                 </div>
                 <div>
-                    <label for="instructions" class="block text-sm font-medium text-gray-700 mb-1">What to extract</label>
+                    <label for="instructions" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">What to extract</label>
                     <textarea id="instructions"
                               name="instructions"
                               rows="2"
                               placeholder="e.g., 'the highlighted text' or 'the sentence about freedom' or 'first paragraph'"
                               required
-                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none">{{ instructions if instructions else '' }}</textarea>
-                    <p class="text-xs text-gray-500 mt-1">
+                              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500">{{ instructions if instructions else '' }}</textarea>
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                         Examples: "the highlighted passage", "sentence containing 'love'", "the quote at the top"
                     </p>
                 </div>
@@ -80,26 +80,26 @@
 </div>
 
 <!-- Save highlight form (collapsible) -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
     <button type="button"
             onclick="toggleSection('manual-section', 'manual-chevron')"
             class="w-full p-4 flex items-center justify-between text-left">
         <div>
-            <h2 class="font-semibold text-gray-900">
+            <h2 class="font-semibold text-gray-900 dark:text-white">
                 {% if extracted_text %}Extracted Text{% else %}Enter Manually{% endif %}
             </h2>
             {% if confidence %}
             <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium mt-1
-                {% if confidence == 'high' %}bg-green-100 text-green-800
-                {% elif confidence == 'medium' %}bg-yellow-100 text-yellow-800
-                {% else %}bg-red-100 text-red-800{% endif %}">
+                {% if confidence == 'high' %}bg-green-100 dark:bg-green-800/50 text-green-800 dark:text-green-300
+                {% elif confidence == 'medium' %}bg-yellow-100 dark:bg-yellow-800/50 text-yellow-800 dark:text-yellow-300
+                {% else %}bg-red-100 dark:bg-red-800/50 text-red-800 dark:text-red-300{% endif %}">
                 Confidence: {{ confidence }}
             </span>
             {% else %}
-            <p class="text-sm text-gray-600 mt-1">Type or paste your highlight text directly.</p>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">Type or paste your highlight text directly.</p>
             {% endif %}
         </div>
-        <svg id="manual-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 transition-transform rotate-180" viewBox="0 0 20 20" fill="currentColor">
+        <svg id="manual-chevron" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-500 dark:text-gray-400 transition-transform rotate-180" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
         </svg>
     </button>
@@ -107,30 +107,30 @@
         <div class="px-4 pb-4">
             <form action="/books/{{ book.id }}/highlights/create" method="post" class="space-y-4">
                 <div>
-                    <label for="text" class="block text-sm font-medium text-gray-700 mb-1">Highlight text *</label>
+                    <label for="text" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Highlight text *</label>
                     <textarea id="text"
                               name="text"
                               rows="5"
                               required
                               placeholder="Type or paste the highlight text..."
-                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none">{{ extracted_text }}</textarea>
+                              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500">{{ extracted_text }}</textarea>
                 </div>
                 <div>
-                    <label for="page_number" class="block text-sm font-medium text-gray-700 mb-1">Page number (optional)</label>
+                    <label for="page_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Page number (optional)</label>
                     <input type="text"
                            id="page_number"
                            name="page_number"
                            value="{{ page_number }}"
                            placeholder="e.g., 42 or 42-43"
-                           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none">
+                           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500">
                 </div>
                 <div>
-                    <label for="note" class="block text-sm font-medium text-gray-700 mb-1">Your note (optional)</label>
+                    <label for="note" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Your note (optional)</label>
                     <textarea id="note"
                               name="note"
                               rows="2"
                               placeholder="Add your thoughts about this highlight..."
-                              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none"></textarea>
+                              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500"></textarea>
                 </div>
                 <button type="submit"
                         class="w-full bg-green-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-green-700 transition">

--- a/app/templates/all_highlights.html
+++ b/app/templates/all_highlights.html
@@ -3,30 +3,30 @@
 {% block title %}All Highlights - Highlight Helper{% endblock %}
 
 {% block content %}
-<h1 class="text-2xl font-bold text-gray-900 mb-6">All Highlights</h1>
+<h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6">All Highlights</h1>
 
 {% if highlights %}
 <div class="space-y-4">
     {% for highlight in highlights %}
-    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-        <blockquote class="highlight-text text-gray-800 border-l-4 border-primary-400 pl-4 mb-3">
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+        <blockquote class="highlight-text text-gray-800 dark:text-gray-200 border-l-4 border-primary-400 dark:border-primary-500 pl-4 mb-3">
             "{{ highlight.text }}"
         </blockquote>
 
         {% if highlight.note %}
-        <p class="text-sm text-gray-600 italic mb-3">Note: {{ highlight.note }}</p>
+        <p class="text-sm text-gray-600 dark:text-gray-400 italic mb-3">Note: {{ highlight.note }}</p>
         {% endif %}
 
         <div class="flex flex-wrap items-center gap-2 text-sm">
             <a href="/books/{{ highlight.book_id }}"
-               class="text-primary-600 hover:text-primary-700 font-medium">
+               class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 font-medium">
                 {{ highlight.book_title }}
             </a>
-            <span class="text-gray-400">by</span>
-            <span class="text-gray-600">{{ highlight.book_author }}</span>
+            <span class="text-gray-400 dark:text-gray-500">by</span>
+            <span class="text-gray-600 dark:text-gray-400">{{ highlight.book_author }}</span>
         </div>
 
-        <div class="flex items-center justify-between text-sm text-gray-500 mt-2 pt-2 border-t border-gray-100">
+        <div class="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400 mt-2 pt-2 border-t border-gray-100 dark:border-gray-700">
             <div class="flex items-center gap-3">
                 {% if highlight.page_number %}
                 <span>Page {{ highlight.page_number }}</span>
@@ -35,7 +35,7 @@
             </div>
             <div class="flex items-center gap-3">
                 {% if highlight.synced_at %}
-                <span class="inline-flex items-center gap-1 text-green-600 px-2 py-1 bg-green-50 rounded" title="Synced to Readwise on {{ highlight.synced_at.strftime('%b %d, %Y') }}">
+                <span class="inline-flex items-center gap-1 text-green-600 dark:text-green-400 px-2 py-1 bg-green-50 dark:bg-green-900/30 rounded" title="Synced to Readwise on {{ highlight.synced_at.strftime('%b %d, %Y') }}">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                     </svg>
@@ -44,7 +44,7 @@
                 {% else %}
                 <button id="sync-btn-{{ highlight.id }}"
                         onclick="syncHighlightToReadwise({{ highlight.id }})"
-                        class="inline-flex items-center gap-1 text-amber-700 px-2 py-1 bg-amber-50 rounded hover:bg-amber-100 transition">
+                        class="inline-flex items-center gap-1 text-amber-700 dark:text-amber-400 px-2 py-1 bg-amber-50 dark:bg-amber-900/30 rounded hover:bg-amber-100 dark:hover:bg-amber-900/50 transition">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" />
                     </svg>
@@ -53,7 +53,7 @@
                 {% endif %}
                 <form action="/highlights/{{ highlight.id }}/delete" method="post"
                       onsubmit="return confirm('Delete this highlight?');">
-                    <button type="submit" class="text-red-600 hover:text-red-700">
+                    <button type="submit" class="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300">
                         Delete
                     </button>
                 </form>
@@ -63,12 +63,12 @@
     {% endfor %}
 </div>
 {% else %}
-<div class="text-center py-12 bg-white rounded-xl shadow-sm border border-gray-200">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto text-gray-300 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+<div class="text-center py-12 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto text-gray-300 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
     </svg>
-    <h2 class="text-xl font-semibold text-gray-900 mb-2">No highlights yet</h2>
-    <p class="text-gray-600 mb-4">Add a book and start collecting highlights.</p>
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">No highlights yet</h2>
+    <p class="text-gray-600 dark:text-gray-400 mb-4">Add a book and start collecting highlights.</p>
     <a href="/books/add"
        class="inline-flex items-center gap-2 bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
@@ -98,9 +98,9 @@ async function syncHighlightToReadwise(highlightId) {
         const data = await response.json();
 
         if (response.ok && data.success) {
-            // Replace button with synced indicator
+            // Replace button with synced indicator (with dark mode support)
             btn.outerHTML = `
-                <span class="inline-flex items-center gap-1 text-green-600 px-2 py-1 bg-green-50 rounded" title="Synced to Readwise">
+                <span class="inline-flex items-center gap-1 text-green-600 dark:text-green-400 px-2 py-1 bg-green-50 dark:bg-green-900/30 rounded" title="Synced to Readwise">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                     </svg>

--- a/app/templates/book_detail.html
+++ b/app/templates/book_detail.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="mb-6">
-    <a href="/" class="text-primary-600 hover:text-primary-700 flex items-center gap-1 text-sm">
+    <a href="/" class="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 flex items-center gap-1 text-sm">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd" />
         </svg>
@@ -13,14 +13,14 @@
 </div>
 
 <!-- Book header -->
-<div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-6">
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-6">
     <div class="flex gap-4">
         <!-- Cover -->
-        <div class="w-24 h-32 sm:w-32 sm:h-44 flex-shrink-0 bg-gray-200 rounded-lg overflow-hidden">
+        <div class="w-24 h-32 sm:w-32 sm:h-44 flex-shrink-0 bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden">
             {% if book.cover_url %}
             <img src="{{ book.cover_url }}" alt="{{ book.title }}" class="w-full h-full object-cover">
             {% else %}
-            <div class="w-full h-full flex items-center justify-center text-gray-400">
+            <div class="w-full h-full flex items-center justify-center text-gray-400 dark:text-gray-500">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
@@ -30,10 +30,10 @@
 
         <!-- Info -->
         <div class="flex-1 min-w-0">
-            <h1 class="text-xl sm:text-2xl font-bold text-gray-900">{{ book.title }}</h1>
-            <p class="text-gray-600 mb-2">{{ book.author }}</p>
+            <h1 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">{{ book.title }}</h1>
+            <p class="text-gray-600 dark:text-gray-400 mb-2">{{ book.author }}</p>
             {% if book.isbn %}
-            <p class="text-sm text-gray-500 mb-3">ISBN: {{ book.isbn }}</p>
+            <p class="text-sm text-gray-500 dark:text-gray-500 mb-3">ISBN: {{ book.isbn }}</p>
             {% endif %}
 
             <div class="flex flex-wrap gap-2 mt-auto">
@@ -47,7 +47,7 @@
                 <form action="/books/{{ book.id }}/delete" method="post"
                       onsubmit="return confirm('Delete this book and all its highlights?');">
                     <button type="submit"
-                            class="bg-red-100 text-red-700 px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-red-200 transition">
+                            class="bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-red-200 dark:hover:bg-red-900/50 transition">
                         Delete Book
                     </button>
                 </form>
@@ -58,7 +58,7 @@
 
 <!-- Highlights -->
 <div class="mb-4 flex items-center justify-between">
-    <h2 class="text-lg font-semibold text-gray-900">
+    <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
         Highlights ({{ highlights|length }})
     </h2>
 </div>
@@ -66,16 +66,16 @@
 {% if highlights %}
 <div class="space-y-4">
     {% for highlight in highlights %}
-    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-        <blockquote class="highlight-text text-gray-800 border-l-4 border-primary-400 pl-4 mb-3">
+    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+        <blockquote class="highlight-text text-gray-800 dark:text-gray-200 border-l-4 border-primary-400 dark:border-primary-500 pl-4 mb-3">
             "{{ highlight.text }}"
         </blockquote>
 
         {% if highlight.note %}
-        <p class="text-sm text-gray-600 italic mb-3">Note: {{ highlight.note }}</p>
+        <p class="text-sm text-gray-600 dark:text-gray-400 italic mb-3">Note: {{ highlight.note }}</p>
         {% endif %}
 
-        <div class="flex items-center justify-between text-sm text-gray-500">
+        <div class="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
             <div class="flex items-center gap-3">
                 {% if highlight.page_number %}
                 <span>Page {{ highlight.page_number }}</span>
@@ -84,7 +84,7 @@
             </div>
             <div class="flex items-center gap-3">
                 {% if highlight.synced_at %}
-                <span class="inline-flex items-center gap-1 text-green-600 px-2 py-1 bg-green-50 rounded" title="Synced to Readwise on {{ highlight.synced_at.strftime('%b %d, %Y') }}">
+                <span class="inline-flex items-center gap-1 text-green-600 dark:text-green-400 px-2 py-1 bg-green-50 dark:bg-green-900/30 rounded" title="Synced to Readwise on {{ highlight.synced_at.strftime('%b %d, %Y') }}">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                     </svg>
@@ -93,7 +93,7 @@
                 {% else %}
                 <button id="sync-btn-{{ highlight.id }}"
                         onclick="syncHighlightToReadwise({{ highlight.id }})"
-                        class="inline-flex items-center gap-1 text-amber-700 px-2 py-1 bg-amber-50 rounded hover:bg-amber-100 transition">
+                        class="inline-flex items-center gap-1 text-amber-700 dark:text-amber-400 px-2 py-1 bg-amber-50 dark:bg-amber-900/30 rounded hover:bg-amber-100 dark:hover:bg-amber-900/50 transition">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" />
                     </svg>
@@ -102,7 +102,7 @@
                 {% endif %}
                 <form action="/highlights/{{ highlight.id }}/delete" method="post"
                       onsubmit="return confirm('Delete this highlight?');">
-                    <button type="submit" class="text-red-600 hover:text-red-700">
+                    <button type="submit" class="text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300">
                         Delete
                     </button>
                 </form>
@@ -112,12 +112,12 @@
     {% endfor %}
 </div>
 {% else %}
-<div class="text-center py-12 bg-white rounded-xl shadow-sm border border-gray-200">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-gray-300 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+<div class="text-center py-12 bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 mx-auto text-gray-300 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
     </svg>
-    <h3 class="text-lg font-medium text-gray-900 mb-2">No highlights yet</h3>
-    <p class="text-gray-600 mb-4">Add your first highlight from this book.</p>
+    <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No highlights yet</h3>
+    <p class="text-gray-600 dark:text-gray-400 mb-4">Add your first highlight from this book.</p>
     <a href="/books/{{ book.id }}/add-highlight"
        class="inline-flex items-center gap-2 bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
@@ -147,9 +147,10 @@ async function syncHighlightToReadwise(highlightId) {
         const data = await response.json();
 
         if (response.ok && data.success) {
-            // Replace button with synced indicator
+            // Replace button with synced indicator (with dark mode support)
+            const isDark = document.documentElement.classList.contains('dark');
             btn.outerHTML = `
-                <span class="inline-flex items-center gap-1 text-green-600 px-2 py-1 bg-green-50 rounded" title="Synced to Readwise">
+                <span class="inline-flex items-center gap-1 text-green-600 dark:text-green-400 px-2 py-1 bg-green-50 dark:bg-green-900/30 rounded" title="Synced to Readwise">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
                     </svg>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="mb-6 flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-gray-900">My Books</h1>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">My Books</h1>
     <a href="/books/add"
        class="bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition flex items-center gap-2">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
@@ -18,13 +18,13 @@
 <div class="grid gap-4 sm:grid-cols-2">
     {% for book in books %}
     <a href="/books/{{ book.id }}"
-       class="book-card bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition flex">
+       class="book-card bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden hover:shadow-md transition flex">
         <!-- Book cover -->
-        <div class="w-20 h-28 sm:w-24 sm:h-32 flex-shrink-0 bg-gray-200">
+        <div class="w-20 h-28 sm:w-24 sm:h-32 flex-shrink-0 bg-gray-200 dark:bg-gray-700">
             {% if book.cover_url %}
             <img src="{{ book.cover_url }}" alt="{{ book.title }}" class="w-full h-full object-cover">
             {% else %}
-            <div class="w-full h-full flex items-center justify-center text-gray-400">
+            <div class="w-full h-full flex items-center justify-center text-gray-400 dark:text-gray-500">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
                 </svg>
@@ -34,11 +34,11 @@
         <!-- Book info -->
         <div class="flex-1 p-3 flex flex-col justify-between min-w-0">
             <div>
-                <h2 class="font-semibold text-gray-900 truncate">{{ book.title }}</h2>
-                <p class="text-sm text-gray-600 truncate">{{ book.author }}</p>
+                <h2 class="font-semibold text-gray-900 dark:text-white truncate">{{ book.title }}</h2>
+                <p class="text-sm text-gray-600 dark:text-gray-400 truncate">{{ book.author }}</p>
             </div>
             <div class="mt-2">
-                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-primary-100 text-primary-800">
+                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-primary-100 dark:bg-primary-900 text-primary-800 dark:text-primary-200">
                     {{ book.highlight_count }} highlight{% if book.highlight_count != 1 %}s{% endif %}
                 </span>
             </div>
@@ -48,11 +48,11 @@
 </div>
 {% else %}
 <div class="text-center py-12">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto text-gray-300 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 mx-auto text-gray-300 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
     </svg>
-    <h2 class="text-xl font-semibold text-gray-900 mb-2">No books yet</h2>
-    <p class="text-gray-600 mb-4">Add your first book to start collecting highlights.</p>
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-2">No books yet</h2>
+    <p class="text-gray-600 dark:text-gray-400 mb-4">Add your first book to start collecting highlights.</p>
     <a href="/books/add"
        class="inline-flex items-center gap-2 bg-primary-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-primary-700 transition">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -3,11 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>{% block title %}Highlight Helper{% endblock %}</title>
     <!-- Tailwind CSS via CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
+            darkMode: 'class',
             theme: {
                 extend: {
                     colors: {
@@ -28,6 +30,39 @@
             }
         }
     </script>
+    <script>
+        // Dark mode initialization - runs before page renders to prevent flash
+        (function() {
+            function getThemePreference() {
+                // Check localStorage first
+                const stored = localStorage.getItem('theme');
+                if (stored === 'dark' || stored === 'light') {
+                    return stored;
+                }
+                // Fall back to system preference
+                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            }
+
+            function applyTheme(theme) {
+                if (theme === 'dark') {
+                    document.documentElement.classList.add('dark');
+                } else {
+                    document.documentElement.classList.remove('dark');
+                }
+            }
+
+            // Apply theme immediately to prevent flash
+            applyTheme(getThemePreference());
+
+            // Listen for system preference changes
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+                // Only auto-switch if user hasn't manually set a preference
+                if (!localStorage.getItem('theme')) {
+                    applyTheme(e.matches ? 'dark' : 'light');
+                }
+            });
+        })();
+    </script>
     <style>
         /* Custom styles for better mobile experience */
         .highlight-text {
@@ -36,16 +71,37 @@
         .book-card:active {
             transform: scale(0.98);
         }
+        /* Smooth theme transitions */
+        html.transitioning,
+        html.transitioning *,
+        html.transitioning *::before,
+        html.transitioning *::after {
+            transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease !important;
+        }
     </style>
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="bg-gray-50 dark:bg-gray-900 min-h-screen transition-colors">
     <!-- Header -->
-    <header class="bg-primary-600 text-white sticky top-0 z-50 shadow-md">
+    <header class="bg-primary-600 dark:bg-gray-800 text-white sticky top-0 z-50 shadow-md">
         <div class="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
             <a href="/" class="text-xl font-bold">Highlight Helper</a>
-            <nav class="flex gap-4">
-                <a href="/" class="hover:text-primary-200 transition">Books</a>
-                <a href="/highlights" class="hover:text-primary-200 transition">All Highlights</a>
+            <nav class="flex items-center gap-4">
+                <a href="/" class="hover:text-primary-200 dark:hover:text-primary-400 transition">Books</a>
+                <a href="/highlights" class="hover:text-primary-200 dark:hover:text-primary-400 transition">All Highlights</a>
+                <!-- Dark mode toggle -->
+                <button id="theme-toggle" type="button"
+                        class="p-2 rounded-lg hover:bg-primary-700 dark:hover:bg-gray-700 transition"
+                        title="Toggle dark mode"
+                        aria-label="Toggle dark mode">
+                    <!-- Sun icon (shown in dark mode) -->
+                    <svg id="theme-icon-light" class="hidden dark:block w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
+                    </svg>
+                    <!-- Moon icon (shown in light mode) -->
+                    <svg id="theme-icon-dark" class="block dark:hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
+                    </svg>
+                </button>
             </nav>
         </div>
     </header>
@@ -56,11 +112,38 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-gray-100 border-t mt-auto py-4 text-center text-gray-600 text-sm">
+    <footer class="bg-gray-100 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 mt-auto py-4 text-center text-gray-600 dark:text-gray-400 text-sm">
         <div class="max-w-4xl mx-auto px-4">
             Highlight Helper - Collect and organize your book highlights
         </div>
     </footer>
+
+    <script>
+        // Theme toggle functionality
+        document.getElementById('theme-toggle').addEventListener('click', function() {
+            // Add transition class for smooth animation
+            document.documentElement.classList.add('transitioning');
+
+            // Toggle theme
+            const isDark = document.documentElement.classList.contains('dark');
+            const newTheme = isDark ? 'light' : 'dark';
+
+            // Update class
+            if (newTheme === 'dark') {
+                document.documentElement.classList.add('dark');
+            } else {
+                document.documentElement.classList.remove('dark');
+            }
+
+            // Save preference
+            localStorage.setItem('theme', newTheme);
+
+            // Remove transition class after animation completes
+            setTimeout(function() {
+                document.documentElement.classList.remove('transitioning');
+            }, 300);
+        });
+    </script>
 
     {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary

- Add dark mode toggle button in header with sun/moon icons
- Detect system preference via `prefers-color-scheme` media query
- Persist user preference in localStorage (overrides system default when set)
- Use Tailwind's `class` strategy for reliable dark mode control
- Add smooth 0.3s transitions when switching themes
- Update all page templates with `dark:` variant classes

## Technical Details

**Theme Detection (in `<head>` to prevent flash):**
1. Check localStorage for saved preference
2. Fall back to system preference via `matchMedia`
3. Apply theme class immediately before page renders
4. Listen for system preference changes (auto-switch if no manual preference set)

**Updated Templates:**
- `layouts/base.html` - Core infrastructure
- `home.html` - Book list
- `book_detail.html` - Book details and highlights
- `add_book.html` - Scan, search, manual entry forms
- `add_highlight.html` - Extract, manual entry forms
- `all_highlights.html` - All highlights view

## Test plan

- [ ] Toggle works: clicking sun/moon icon switches theme
- [ ] System preference: respects OS dark/light mode on first visit
- [ ] Persistence: refreshing page keeps selected theme
- [ ] Override: manual toggle overrides system preference
- [ ] All pages render correctly in both light and dark modes
- [ ] Works on Chrome (iOS, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)