### PR TITLE
fix: Exclude notes from Readwise sync (Issue #41)

### DIFF
--- a/app/api/readwise.py
+++ b/app/api/readwise.py
@@ -1,5 +1,6 @@
 """Readwise integration API routes."""
 
+import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -13,8 +14,10 @@ from app.api.schemas import (
 )
 from app.core.database import get_db
 from app.models.book import Book
-from app.models.highlight import Highlight
+from app.models.highlight import AnnotationType, Highlight
 from app.services.readwise import ReadwiseService, get_readwise_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/readwise", tags=["readwise"])
 
@@ -60,10 +63,29 @@ async def sync_all_highlights(
             detail="Readwise API token not configured",
         )
 
-    # Get all unsynced highlights with their books
-    query = select(Highlight, Book).join(Book).where(Highlight.synced_at.is_(None))
+    # Get all unsynced highlights with their books (excluding notes)
+    query = (
+        select(Highlight, Book)
+        .join(Book)
+        .where(Highlight.synced_at.is_(None))
+        .where(Highlight.type == AnnotationType.HIGHLIGHT)
+    )
     result = await db.execute(query)
     rows = result.all()
+
+    # Log if there are notes being excluded
+    notes_query = (
+        select(Highlight)
+        .where(Highlight.synced_at.is_(None))
+        .where(Highlight.type == AnnotationType.NOTE)
+    )
+    notes_result = await db.execute(notes_query)
+    notes_count = len(notes_result.all())
+    if notes_count > 0:
+        logger.info(
+            "Skipping %d note(s) during sync - notes are not supported by Readwise",
+            notes_count,
+        )
 
     if not rows:
         return ReadwiseBatchSyncResponse(total=0, synced=0, failed=0)
@@ -130,6 +152,17 @@ async def sync_highlight(
 
     highlight, book = row
 
+    # Notes cannot be synced to Readwise
+    if highlight.type == AnnotationType.NOTE:
+        logger.info(
+            "Rejecting sync request for note id=%d - notes are not supported by Readwise",
+            highlight_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Notes cannot be synced to Readwise",
+        )
+
     # Use PATCH if highlight was previously synced, otherwise POST
     if highlight.readwise_id:
         # Update existing highlight on Readwise
@@ -188,12 +221,31 @@ async def sync_book_highlights(
             detail="Book not found",
         )
 
-    # Get unsynced highlights for this book
+    # Get unsynced highlights for this book (excluding notes)
     query = (
-        select(Highlight).where(Highlight.book_id == book_id).where(Highlight.synced_at.is_(None))
+        select(Highlight)
+        .where(Highlight.book_id == book_id)
+        .where(Highlight.synced_at.is_(None))
+        .where(Highlight.type == AnnotationType.HIGHLIGHT)
     )
     result = await db.execute(query)
     highlights = result.scalars().all()
+
+    # Log if there are notes being excluded
+    notes_query = (
+        select(Highlight)
+        .where(Highlight.book_id == book_id)
+        .where(Highlight.synced_at.is_(None))
+        .where(Highlight.type == AnnotationType.NOTE)
+    )
+    notes_result = await db.execute(notes_query)
+    notes_count = len(notes_result.scalars().all())
+    if notes_count > 0:
+        logger.info(
+            "Skipping %d note(s) for book id=%d during sync - notes are not supported by Readwise",
+            notes_count,
+            book_id,
+        )
 
     if not highlights:
         return ReadwiseBatchSyncResponse(total=0, synced=0, failed=0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,3 +248,21 @@ async def synced_highlight(test_session: AsyncSession, sample_book):
     await test_session.flush()
     await test_session.refresh(highlight)
     return highlight
+
+
+@pytest.fixture
+async def sample_note(test_session: AsyncSession, sample_book):
+    """Create a sample note (not a highlight) for testing."""
+    from app.models.highlight import AnnotationType, Highlight
+
+    note = Highlight(
+        book_id=sample_book.id,
+        text=None,  # Notes don't have highlight text
+        note="This is a standalone note about the book.",
+        page_number="50",
+        type=AnnotationType.NOTE,
+    )
+    test_session.add(note)
+    await test_session.flush()
+    await test_session.refresh(note)
+    return note

--- a/tests/integration/test_api_readwise.py
+++ b/tests/integration/test_api_readwise.py
@@ -96,3 +96,39 @@ class TestReadwiseAPI:
         """Test syncing all highlights when Readwise not configured."""
         response = await client_readwise_unconfigured.post("/api/readwise/sync/all")
         assert response.status_code == 400
+
+    async def test_sync_single_note_rejected(self, client, sample_note):
+        """Test that syncing a single note returns an error."""
+        response = await client.post(f"/api/readwise/sync/{sample_note.id}")
+        assert response.status_code == 400
+        assert "Notes cannot be synced" in response.json()["detail"]
+
+    async def test_sync_all_excludes_notes(self, client, sample_highlight, sample_note):
+        """Test that sync all only syncs highlights, not notes."""
+        # Ensure both fixtures are created
+        _ = sample_highlight.id
+        _ = sample_note.id
+
+        response = await client.post("/api/readwise/sync/all")
+        assert response.status_code == 200
+        data = response.json()
+        # Only the highlight should be synced, not the note
+        assert data["total"] == 1
+        assert data["synced"] == 1
+        assert data["failed"] == 0
+
+    async def test_sync_book_excludes_notes(
+        self, client, sample_book, sample_highlight, sample_note
+    ):
+        """Test that sync book only syncs highlights, not notes."""
+        # Ensure fixtures are created
+        _ = sample_highlight.id
+        _ = sample_note.id
+
+        response = await client.post(f"/api/readwise/sync/book/{sample_book.id}")
+        assert response.status_code == 200
+        data = response.json()
+        # Only the highlight should be synced, not the note
+        assert data["total"] == 1
+        assert data["synced"] == 1
+        assert data["failed"] == 0


### PR DESCRIPTION
## Summary

Fixes #41 - Notes should not be synced to Readwise.

This PR ensures that only highlights (type=HIGHLIGHT) are synced to Readwise, while notes (type=NOTE) are excluded from all sync operations.

## Research

The codebase has two annotation types stored in the `highlights` table:
- **HIGHLIGHT** - A highlighted passage from the book (has `text` field)
- **NOTE** - A standalone note (may have no `text`, just `note` field)

There are 4 sync trigger points:
1. Auto-sync on highlight creation (API) - Already correct (only creates HIGHLIGHTs)
2. Auto-sync on highlight creation (Web form) - Already correct (only creates HIGHLIGHTs)
3. Manual sync single highlight - **Fixed**: Now rejects NOTEs with 400 error
4. Manual batch sync (all/book) - **Fixed**: Now filters out NOTEs from queries

## Changes

- **app/api/readwise.py**: 
  - Added `AnnotationType` import
  - Updated `sync_all_highlights()` to filter out notes
  - Updated `sync_highlight()` to reject notes with 400 error
  - Updated `sync_book_highlights()` to filter out notes
  
- **tests/conftest.py**: Added `sample_note` fixture

- **tests/integration/test_api_readwise.py**: Added 3 test cases for note exclusion

## Test plan

- [x] All existing tests pass (151 tests)
- [x] New test: `test_sync_note_rejected` - Verifies single note sync returns 400
- [x] New test: `test_sync_all_excludes_notes` - Verifies batch sync excludes notes
- [x] New test: `test_sync_book_excludes_notes` - Verifies book sync excludes notes

Generated with [Claude Code](https://claude.com/claude-code)