### PR TITLE
feat: Add timeline view for highlights and notes (Issue #42)

### DIFF
--- a/app/api/views.py
+++ b/app/api/views.py
@@ -240,12 +240,61 @@ async def book_detail(
     highlights_result = await db.execute(highlights_query)
     highlights = highlights_result.scalars().all()
 
+    # Build timeline data for highlights with page numbers
+    timeline_items = []
+    page_numbers = []
+
+    for h in highlights:
+        if h.page_number:
+            try:
+                # Handle page ranges like "42-43" by taking the first number
+                page_num = int(h.page_number.split("-")[0].strip())
+                page_numbers.append(page_num)
+                preview_text = h.text or h.note or ""
+                if len(preview_text) > 50:
+                    preview_text = preview_text[:50] + "..."
+                timeline_items.append(
+                    {
+                        "id": h.id,
+                        "page_number": page_num,
+                        "type": h.type.value if hasattr(h.type, "value") else str(h.type),
+                        "preview": preview_text,
+                    }
+                )
+            except (ValueError, AttributeError):
+                # Skip highlights with non-numeric page numbers
+                pass
+
+    min_page = min(page_numbers) if page_numbers else 0
+    max_page = max(page_numbers) if page_numbers else 0
+
+    for item in timeline_items:
+        if max_page > min_page:
+            item["position"] = ((item["page_number"] - min_page) / (max_page - min_page)) * 100
+        else:
+            item["position"] = 50  # Center single item
+
+    # Handle overlapping dots: group items on the same page and offset nearby items
+    # Sort by page number for consistent positioning
+    timeline_items.sort(key=lambda x: (x["page_number"], x["id"]))
+
+    # Add vertical offset for items on same or nearby pages
+    page_count: dict[int, int] = {}
+    for item in timeline_items:
+        page = item["page_number"]
+        count = page_count.get(page, 0)
+        item["offset_index"] = count
+        page_count[page] = count + 1
+
     return templates.TemplateResponse(
         request,
         "book_detail.html",
         {
             "book": book,
             "highlights": highlights,
+            "timeline_items": timeline_items,
+            "timeline_min_page": min_page,
+            "timeline_max_page": max_page,
         },
     )
 

--- a/app/templates/book_detail.html
+++ b/app/templates/book_detail.html
@@ -63,6 +63,52 @@
     </div>
 </div>
 
+<!-- Timeline Section -->
+{% if timeline_items %}
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-6">
+    <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">Reading Progress</h3>
+
+    <!-- Timeline -->
+    <div class="relative">
+        <!-- Page labels - only show both if different -->
+        <div class="flex justify-between text-xs text-gray-500 dark:text-gray-400 mb-2">
+            <span>p. {{ timeline_min_page }}</span>
+            {% if timeline_min_page != timeline_max_page %}
+            <span>p. {{ timeline_max_page }}</span>
+            {% endif %}
+        </div>
+
+        <!-- Track -->
+        <div class="relative h-3 bg-gray-200 dark:bg-gray-700 rounded-full">
+            <!-- Dots -->
+            {% for item in timeline_items %}
+            <button
+                class="absolute top-1/2 -translate-x-1/2 w-4 h-4 rounded-full
+                       {% if item.type == 'note' %}bg-blue-500 hover:bg-blue-600{% else %}bg-primary-500 hover:bg-primary-600{% endif %}
+                       shadow-sm hover:scale-125 transition-transform cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+                style="left: {{ item.position }}%; transform: translateX(-50%) translateY(calc(-50% - {{ item.offset_index * 18 }}px));"
+                title="Page {{ item.page_number }}: {{ item.preview | e }}"
+                onclick="scrollToHighlight({{ item.id }})"
+                type="button">
+            </button>
+            {% endfor %}
+        </div>
+
+        <!-- Legend -->
+        <div class="flex items-center gap-4 mt-3 text-xs text-gray-500 dark:text-gray-400">
+            <div class="flex items-center gap-1">
+                <span class="w-3 h-3 rounded-full bg-primary-500"></span>
+                <span>Highlights</span>
+            </div>
+            <div class="flex items-center gap-1">
+                <span class="w-3 h-3 rounded-full bg-blue-500"></span>
+                <span>Notes</span>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Highlights & Notes -->
 <div class="mb-4 flex items-center justify-between">
     <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
@@ -73,7 +119,7 @@
 {% if highlights %}
 <div class="space-y-4">
     {% for highlight in highlights %}
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4">
+    <div id="highlight-{{ highlight.id }}" class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4">
         {% if highlight.type == 'note' %}
         <!-- Standalone Note -->
         <div class="flex items-start gap-2 mb-3">
@@ -177,6 +223,18 @@
 {% endif %}
 
 <script>
+function scrollToHighlight(highlightId) {
+    const card = document.getElementById(`highlight-${highlightId}`);
+    if (card) {
+        card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        // Flash effect
+        card.classList.add('ring-2', 'ring-primary-500');
+        setTimeout(() => {
+            card.classList.remove('ring-2', 'ring-primary-500');
+        }, 1500);
+    }
+}
+
 async function syncHighlightToReadwise(highlightId) {
     const btn = document.getElementById(`sync-btn-${highlightId}`);
     const btnText = document.getElementById(`sync-btn-text-${highlightId}`);

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -124,7 +124,7 @@ class TestBookDetailView:
         assert response.status_code == 200
         assert sample_book.title in response.text
         assert sample_book.author in response.text
-        assert "No highlights yet" in response.text
+        assert "No highlights or notes yet" in response.text
 
     async def test_book_detail_with_highlights(
         self, client: AsyncClient, sample_book, sample_highlight
@@ -354,3 +354,114 @@ class TestDeleteHighlightView:
         )
         assert response.status_code == 303
         assert f"/books/{sample_book.id}" in response.headers["location"]
+
+
+class TestTimelineView:
+    """Tests for the timeline feature on book detail page."""
+
+    async def test_book_detail_shows_timeline_with_page_numbers(
+        self, client: AsyncClient, sample_book, sample_highlight
+    ):
+        """Test that timeline is shown when highlights have page numbers."""
+        response = await client.get(f"/books/{sample_book.id}")
+        assert response.status_code == 200
+        # Timeline should be shown (sample_highlight has page_number="42")
+        assert "Reading Progress" in response.text
+        assert "p. 42" in response.text
+        # Check for legend
+        assert "Highlights" in response.text
+        assert "Notes" in response.text
+
+    async def test_book_detail_hides_timeline_without_page_numbers(
+        self, client: AsyncClient, test_session, sample_book
+    ):
+        """Test that timeline is hidden when no highlights have page numbers."""
+        from app.models.highlight import Highlight
+
+        # Create highlight without page number
+        highlight = Highlight(
+            book_id=sample_book.id,
+            text="Highlight without page",
+            page_number=None,
+        )
+        test_session.add(highlight)
+        await test_session.commit()
+
+        response = await client.get(f"/books/{sample_book.id}")
+        assert response.status_code == 200
+        # Timeline should NOT be shown
+        assert "Reading Progress" not in response.text
+
+    async def test_book_detail_timeline_shows_correct_page_range(
+        self, client: AsyncClient, test_session, sample_book
+    ):
+        """Test that timeline shows correct min/max page numbers."""
+        from app.models.highlight import Highlight
+
+        # Create highlights at different pages
+        highlight1 = Highlight(
+            book_id=sample_book.id,
+            text="First highlight",
+            page_number="10",
+        )
+        highlight2 = Highlight(
+            book_id=sample_book.id,
+            text="Last highlight",
+            page_number="200",
+        )
+        test_session.add_all([highlight1, highlight2])
+        await test_session.commit()
+
+        response = await client.get(f"/books/{sample_book.id}")
+        assert response.status_code == 200
+        assert "p. 10" in response.text
+        assert "p. 200" in response.text
+
+    async def test_book_detail_highlight_cards_have_ids(
+        self, client: AsyncClient, sample_book, sample_highlight
+    ):
+        """Test that highlight cards have IDs for timeline scroll targeting."""
+        response = await client.get(f"/books/{sample_book.id}")
+        assert response.status_code == 200
+        # Check for highlight card ID
+        assert f'id="highlight-{sample_highlight.id}"' in response.text
+
+    async def test_book_detail_timeline_single_item_no_duplicate_label(
+        self, client: AsyncClient, sample_book, sample_highlight
+    ):
+        """Test that single item timeline does not show duplicate page labels."""
+        response = await client.get(f"/books/{sample_book.id}")
+        assert response.status_code == 200
+        # Should only show one "p. 42" label, not two
+        # Count occurrences of "p. 42" in page labels section
+        # The label should appear once (not twice at both ends)
+        content = response.text
+        # The pattern should not have two adjacent page labels with same value
+        assert "p. 42</span>" in content
+        # When min == max, we should NOT have a second label
+        # The implementation hides the second label when timeline_min_page == timeline_max_page
+
+    async def test_book_detail_timeline_escapes_preview_text(
+        self, client: AsyncClient, test_session, sample_book
+    ):
+        """Test that preview text in tooltip is properly escaped (XSS prevention)."""
+        from app.models.highlight import Highlight
+
+        # Create highlight with potentially dangerous content
+        highlight = Highlight(
+            book_id=sample_book.id,
+            text='Test <script>alert("xss")</script> text',
+            page_number="50",
+        )
+        test_session.add(highlight)
+        await test_session.commit()
+
+        response = await client.get(f"/books/{sample_book.id}")
+        assert response.status_code == 200
+        # The script tag should be escaped in the title attribute
+        assert "<script>" not in response.text or "&lt;script&gt;" in response.text
+        assert (
+            'alert("xss")' not in response.text
+            or "&#34;" in response.text
+            or "&quot;" in response.text
+        )


### PR DESCRIPTION
## Summary

Add a visual timeline component to the book detail page that displays highlights and notes as positioned dots along a horizontal track, where position corresponds to page number in the book.

- Horizontal bar representing page range (min to max page number)
- Dots positioned proportionally based on page number
- Color-coded: yellow/primary for highlights, blue for notes  
- Click interaction to scroll to corresponding highlight card
- Hover tooltip showing page number and preview text
- Only shown when highlights have numeric page numbers
- Dark mode support

Closes #42

## Research and Plan

See `research.md` and `plan.md` for detailed analysis of the codebase and implementation plan.

### Key Implementation Details

**Backend (`app/api/views.py`):**
- Parse page numbers from highlights (handles ranges like "42-43")
- Calculate min/max page range
- Compute percentage positions for each dot
- Pass timeline data to template

**Frontend (`app/templates/book_detail.html`):**
- Timeline component with track and positioned dots
- Click handler to smooth scroll to highlight cards
- Flash effect on scrolled-to card
- Legend showing highlight vs note colors

## Test plan

- [x] Unit/integration tests pass (`just test`)
- [x] New tests added for timeline functionality:
  - `test_book_detail_shows_timeline_with_page_numbers`
  - `test_book_detail_hides_timeline_without_page_numbers`
  - `test_book_detail_timeline_shows_correct_page_range`
  - `test_book_detail_highlight_cards_have_ids`
- [x] Lint and format checks pass
- [ ] Manual validation in browser
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)