### PR TITLE
feat: Improve database durability with WAL mode and backup support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
 # OpenAI API Key for image processing
 OPENAI_API_KEY=your_openai_api_key_here
 
-# Database URL (defaults to SQLite)
+# Database URL (defaults to SQLite with WAL mode enabled automatically)
 DATABASE_URL=sqlite+aiosqlite:///./highlight_helper.db
+
+# Backup rotation (number of backups to keep)
+# KEEP_BACKUPS=7
 
 # Environment
 ENVIRONMENT=development

--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,13 @@ htmlcov/
 
 # Database
 *.db
+*.db-wal
+*.db-shm
 *.sqlite
 *.sqlite3
+
+# Database backups
+backups/
 
 # SSL Certificates (local development)
 certs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ COPY --from=builder /app/.venv /app/.venv
 COPY app/ ./app/
 COPY static/ ./static/
 
-# Create directories for data and certs (will be mounted as volumes)
-RUN mkdir -p /app/data /app/certs && chown -R appuser:appuser /app
+# Create directories for data, certs, and backups (will be mounted as volumes)
+RUN mkdir -p /app/data /app/certs /app/backups && chown -R appuser:appuser /app
 
 # Switch to non-root user
 USER appuser

--- a/Justfile
+++ b/Justfile
@@ -134,3 +134,31 @@ service-logs:
 # Restart the service (requires sudo)
 service-restart:
     sudo systemctl restart highlight-helper
+
+# =============================================================================
+# Database Backup Commands
+# =============================================================================
+
+# Create a database backup
+backup:
+    ./scripts/backup_db.sh
+
+# List available backups
+backup-list:
+    @echo "Available backups:"
+    @find ./backups -name "highlight_helper_*.db" -type f 2>/dev/null | sort | while read backup; do \
+        size=$$(du -h "$$backup" | cut -f1); \
+        echo "  $$(basename $$backup) ($$size)"; \
+    done || echo "  No backups found"
+
+# Restore from a backup file
+backup-restore file:
+    @if [ ! -f "{{file}}" ]; then \
+        echo "Error: Backup file not found: {{file}}"; \
+        exit 1; \
+    fi
+    @echo "Restoring from: {{file}}"
+    @echo "This will overwrite the current database. Press Ctrl+C to cancel..."
+    @sleep 3
+    cp "{{file}}" ./data/highlight_helper.db
+    @echo "Database restored successfully."

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,12 +1,16 @@
 """Database connection and session management."""
 
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 settings = get_settings()
 
@@ -14,6 +18,41 @@ engine = create_async_engine(
     settings.database_url,
     echo=settings.is_development,
 )
+
+
+def _configure_sqlite_pragmas(dbapi_connection, connection_record):
+    """Configure SQLite pragmas for durability and performance.
+
+    These settings improve crash recovery and concurrent access:
+    - journal_mode=WAL: Write-Ahead Logging for better crash recovery
+    - synchronous=NORMAL: Good durability with WAL mode
+    - busy_timeout=5000: Wait 5 seconds on locks before failing
+    """
+    cursor = dbapi_connection.cursor()
+
+    # Enable WAL mode for better crash recovery and concurrent reads
+    cursor.execute("PRAGMA journal_mode=WAL")
+    result = cursor.fetchone()
+    if result and result[0].lower() != "wal":
+        logger.warning(
+            f"Failed to enable WAL mode, journal_mode is: {result[0]}. "
+            "This may indicate the database is in use or a permission issue."
+        )
+    else:
+        logger.debug("SQLite WAL mode enabled successfully")
+
+    # NORMAL synchronous is safe with WAL and provides good performance
+    cursor.execute("PRAGMA synchronous=NORMAL")
+
+    # Wait 5 seconds on locks before failing
+    cursor.execute("PRAGMA busy_timeout=5000")
+
+    cursor.close()
+
+
+# Register the pragma configuration for SQLite connections
+if "sqlite" in settings.database_url:
+    event.listen(engine.sync_engine, "connect", _configure_sqlite_pragmas)
 
 async_session_maker = async_sessionmaker(
     engine,
@@ -49,7 +88,7 @@ async def init_db() -> None:
 
 def _run_migrations(conn) -> None:
     """Run database migrations for schema changes."""
-    from sqlalchemy import inspect, text
+    from sqlalchemy import inspect
 
     inspector = inspect(conn)
 
@@ -74,7 +113,8 @@ def _run_migrations(conn) -> None:
         text_col = columns.get("text", {})
         if text_col and text_col.get("nullable") is False:
             # SQLite workaround: create new table, copy data, drop old, rename
-            conn.execute(text("""
+            conn.execute(
+                text("""
                 CREATE TABLE IF NOT EXISTS highlights_new (
                     id INTEGER PRIMARY KEY,
                     book_id INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
@@ -87,12 +127,15 @@ def _run_migrations(conn) -> None:
                     synced_at TIMESTAMP,
                     sync_status VARCHAR(20) DEFAULT 'PENDING'
                 )
-            """))
-            conn.execute(text("""
+            """)
+            )
+            conn.execute(
+                text("""
                 INSERT INTO highlights_new
                 SELECT id, book_id, text, note, page_number, created_at, type, readwise_id, synced_at, sync_status
                 FROM highlights
-            """))
+            """)
+            )
             conn.execute(text("DROP TABLE highlights"))
             conn.execute(text("ALTER TABLE highlights_new RENAME TO highlights"))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     volumes:
       # Database persistence
       - ./data:/app/data
+      # Database backups
+      - ./backups:/app/backups
       # SSL certificates (optional, for HTTPS)
       - ./certs:/app/certs:ro
 

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Database backup script for Highlight Helper
+# Creates consistent SQLite backups with integrity verification
+#
+# Usage: ./scripts/backup_db.sh [database_path] [backup_dir]
+#
+# Features:
+# - Uses SQLite .backup command for consistent snapshots
+# - Checkpoints WAL before backup
+# - Verifies backup integrity
+# - Rotates old backups (keeps last N backups)
+# - Sets secure file permissions on backups
+
+set -euo pipefail
+
+# Configuration
+DEFAULT_DB_PATH="./data/highlight_helper.db"
+DEFAULT_BACKUP_DIR="./backups"
+KEEP_BACKUPS="${KEEP_BACKUPS:-7}"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+
+# Parse arguments
+DB_PATH="${1:-$DEFAULT_DB_PATH}"
+BACKUP_DIR="${2:-$DEFAULT_BACKUP_DIR}"
+
+# Security: Validate paths to prevent directory traversal
+validate_path() {
+    local path="$1"
+    local description="$2"
+
+    # Check for null bytes
+    if [[ "$path" == *$'\0'* ]]; then
+        echo "Error: $description contains null bytes" >&2
+        exit 1
+    fi
+
+    # Check for directory traversal attempts
+    # Normalize the path and check it doesn't escape
+    local normalized
+    normalized=$(realpath -m "$path" 2>/dev/null) || {
+        echo "Error: Cannot normalize $description: $path" >&2
+        exit 1
+    }
+
+    # For backup directory, ensure it's under the project or an absolute path we trust
+    if [[ "$description" == "backup directory" ]]; then
+        # Allow absolute paths or paths relative to current directory
+        if [[ ! "$normalized" =~ ^/ ]] && [[ "$normalized" == *".."* ]]; then
+            echo "Error: $description appears to escape current directory" >&2
+            exit 1
+        fi
+    fi
+
+    echo "$normalized"
+}
+
+# Validate paths
+DB_PATH=$(validate_path "$DB_PATH" "database path")
+BACKUP_DIR=$(validate_path "$BACKUP_DIR" "backup directory")
+
+BACKUP_FILE="$BACKUP_DIR/highlight_helper_$TIMESTAMP.db"
+
+echo "=== Database Backup ==="
+echo "Source: $DB_PATH"
+echo "Destination: $BACKUP_FILE"
+echo ""
+
+# Check if source database exists
+if [[ ! -f "$DB_PATH" ]]; then
+    echo "Error: Database not found at $DB_PATH" >&2
+    exit 1
+fi
+
+# Create backup directory with secure permissions
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+
+# Checkpoint WAL to ensure all changes are in main database
+# Use readonly mode to avoid modifying the source
+echo "Checkpointing WAL..."
+sqlite3 "file:${DB_PATH}?mode=ro" "PRAGMA wal_checkpoint(TRUNCATE);" 2>/dev/null || {
+    echo "Note: WAL checkpoint skipped (database may not be in WAL mode or is locked)"
+}
+
+# Create backup using SQLite's backup command with readonly mode
+echo "Creating backup..."
+sqlite3 "file:${DB_PATH}?mode=ro" ".backup '$BACKUP_FILE'"
+
+# Set secure permissions on backup file (readable only by owner)
+chmod 600 "$BACKUP_FILE"
+
+# Verify backup integrity
+echo "Verifying backup integrity..."
+INTEGRITY=$(sqlite3 "$BACKUP_FILE" "PRAGMA integrity_check;")
+if [[ "$INTEGRITY" != "ok" ]]; then
+    echo "Error: Backup integrity check failed!" >&2
+    echo "$INTEGRITY" >&2
+    rm -f "$BACKUP_FILE"
+    exit 1
+fi
+
+echo "Backup verified successfully."
+
+# Get backup size
+BACKUP_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+echo "Backup size: $BACKUP_SIZE"
+
+# Rotate old backups
+echo ""
+echo "Rotating old backups (keeping last $KEEP_BACKUPS)..."
+BACKUP_COUNT=$(find "$BACKUP_DIR" -name "highlight_helper_*.db" -type f | wc -l)
+if [[ $BACKUP_COUNT -gt $KEEP_BACKUPS ]]; then
+    # Sort by name (which includes timestamp) and remove oldest
+    DELETE_COUNT=$((BACKUP_COUNT - KEEP_BACKUPS))
+    find "$BACKUP_DIR" -name "highlight_helper_*.db" -type f | sort | head -n "$DELETE_COUNT" | while read -r old_backup; do
+        echo "  Removing: $(basename "$old_backup")"
+        rm -f "$old_backup"
+    done
+fi
+
+echo ""
+echo "=== Backup Complete ==="
+echo "Backup saved to: $BACKUP_FILE"
+
+# List all backups
+echo ""
+echo "Available backups:"
+find "$BACKUP_DIR" -name "highlight_helper_*.db" -type f | sort | while read -r backup; do
+    size=$(du -h "$backup" | cut -f1)
+    perms=$(stat -c "%a" "$backup")
+    echo "  $(basename "$backup") ($size, mode $perms)"
+done

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,0 +1,122 @@
+"""Tests for database durability configuration."""
+
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.core.database import _configure_sqlite_pragmas
+
+
+class TestSQLitePragmas:
+    """Tests for SQLite pragma configuration."""
+
+    def test_configure_sqlite_pragmas_sets_wal_mode(self):
+        """Test that WAL mode is enabled."""
+        mock_connection = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connection.cursor.return_value = mock_cursor
+
+        # Simulate WAL mode being successfully set
+        mock_cursor.fetchone.return_value = ("wal",)
+
+        _configure_sqlite_pragmas(mock_connection, None)
+
+        # Verify all pragmas are set
+        pragma_calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+        assert "PRAGMA journal_mode=WAL" in pragma_calls
+        assert "PRAGMA synchronous=NORMAL" in pragma_calls
+        assert "PRAGMA busy_timeout=5000" in pragma_calls
+
+    def test_configure_sqlite_pragmas_warns_on_wal_failure(self):
+        """Test that a warning is logged if WAL mode fails to enable."""
+        mock_connection = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connection.cursor.return_value = mock_cursor
+
+        # Simulate WAL mode NOT being set (returns 'delete' instead)
+        mock_cursor.fetchone.return_value = ("delete",)
+
+        with patch("app.core.database.logger") as mock_logger:
+            _configure_sqlite_pragmas(mock_connection, None)
+
+            # Verify warning was logged
+            mock_logger.warning.assert_called_once()
+            warning_msg = mock_logger.warning.call_args[0][0]
+            assert "Failed to enable WAL mode" in warning_msg
+            assert "delete" in warning_msg
+
+    def test_configure_sqlite_pragmas_logs_success(self):
+        """Test that success is logged when WAL mode is enabled."""
+        mock_connection = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connection.cursor.return_value = mock_cursor
+
+        # Simulate WAL mode being successfully set
+        mock_cursor.fetchone.return_value = ("wal",)
+
+        with patch("app.core.database.logger") as mock_logger:
+            _configure_sqlite_pragmas(mock_connection, None)
+
+            # Verify debug log for success
+            mock_logger.debug.assert_called_once()
+            debug_msg = mock_logger.debug.call_args[0][0]
+            assert "WAL mode enabled successfully" in debug_msg
+
+    def test_configure_sqlite_pragmas_closes_cursor(self):
+        """Test that the cursor is properly closed after configuration."""
+        mock_connection = MagicMock()
+        mock_cursor = MagicMock()
+        mock_connection.cursor.return_value = mock_cursor
+        mock_cursor.fetchone.return_value = ("wal",)
+
+        _configure_sqlite_pragmas(mock_connection, None)
+
+        mock_cursor.close.assert_called_once()
+
+
+class TestWALModeIntegration:
+    """Integration tests for WAL mode with real SQLite database."""
+
+    @pytest.mark.asyncio
+    async def test_wal_mode_enabled_on_real_database(self):
+        """Test that WAL mode is actually enabled on a real SQLite database."""
+        import sqlite3
+
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        # Create a real connection and configure pragmas
+        conn = sqlite3.connect(db_path)
+        _configure_sqlite_pragmas(conn, None)
+
+        # Verify WAL mode is enabled
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA journal_mode")
+        result = cursor.fetchone()
+        assert result[0].lower() == "wal"
+
+        # Verify synchronous mode
+        cursor.execute("PRAGMA synchronous")
+        result = cursor.fetchone()
+        # NORMAL = 1
+        assert result[0] == 1
+
+        # Verify busy_timeout
+        cursor.execute("PRAGMA busy_timeout")
+        result = cursor.fetchone()
+        assert result[0] == 5000
+
+        cursor.close()
+        conn.close()
+
+        # Cleanup
+        import os
+
+        os.unlink(db_path)
+        # WAL files may have been created
+        for suffix in ["-wal", "-shm"]:
+            try:
+                os.unlink(db_path + suffix)
+            except FileNotFoundError:
+                pass


### PR DESCRIPTION
## Summary

Addresses Issue #39 - Improve the durability of the local database so highlights don't get lost.

This PR improves SQLite database durability through:

- **WAL Mode**: Enables Write-Ahead Logging for better crash recovery and concurrent read/write performance
- **Backup System**: Adds automated backup script with integrity verification and rotation
- **Justfile Commands**: Easy-to-use backup/restore commands

## Research Findings

### Current State (Before This PR)
- SQLite used default rollback journal mode (less durable)
- No backup mechanism existed
- No explicit sync settings configured

### Changes Made
1. **WAL Mode Configuration** (`app/core/database.py`)
   - `PRAGMA journal_mode=WAL` - Better crash recovery, concurrent readers
   - `PRAGMA synchronous=NORMAL` - Good durability with WAL
   - `PRAGMA busy_timeout=5000` - 5 second wait on locks

2. **Backup Script** (`scripts/backup_db.sh`)
   - Uses SQLite's `.backup` command for consistent backups
   - Checkpoints WAL before backup
   - Verifies backup integrity
   - Rotates old backups (default: keep 7)

3. **Justfile Commands**
   - `just backup` - Create a database backup
   - `just backup-list` - List available backups
   - `just backup-restore <file>` - Restore from backup

4. **Docker Configuration**
   - Added backups volume mount
   - Updated gitignore for WAL files and directories

## Test Plan

- [x] Unit tests pass (4 new tests for durability settings)
- [x] All 152 tests pass
- [x] Linting and formatting checks pass
- [ ] Manual verification: Start app, verify `.db-wal` file is created
- [ ] Manual verification: Run `just backup` and verify backup is created

## Files Changed

| File | Change |
|------|--------|
| `app/core/database.py` | Add WAL mode and pragma configuration |
| `scripts/backup_db.sh` | New backup script |
| `tests/unit/test_database.py` | New tests for durability settings |
| `Justfile` | Add backup commands |
| `docker-compose.yml` | Add backups volume |
| `Dockerfile` | Create backups directory |
| `.gitignore` | Exclude WAL files and backup directory |
| `.env.example` | Document WAL mode |

---

Closes #39

:robot: Generated with [Claude Code](https://claude.com/claude-code)