### PR TITLE
Fix flaky delete e2e tests (Issue #30)

### DIFF
--- a/tests/e2e/test_user_flows.py
+++ b/tests/e2e/test_user_flows.py
@@ -393,7 +393,6 @@ class TestEditHighlightFlow:
 class TestDeleteOperations:
     """Tests for delete functionality."""
 
-    @pytest.mark.skip(reason="Flaky in CI due to confirm dialog handling in headless mode")
     def test_delete_highlight(self, server, browser_context):
         """Test deleting a highlight."""
         page = browser_context.new_page()
@@ -422,22 +421,19 @@ class TestDeleteOperations:
         # Verify highlight exists
         assert page.locator("text=Highlight to be deleted").is_visible()
 
-        # Find the delete button for the highlight (not the book delete button)
-        # The highlight delete is in a form with action /highlights/{id}/delete
+        # Override window.confirm to always return true (avoids flaky dialog handling)
+        page.evaluate("window.confirm = () => true")
+
+        # Find and click the delete button for the highlight
         delete_button = page.locator("form[action*='/highlights/'] button:has-text('Delete')").first
+        delete_button.click()
+        page.wait_for_load_state("networkidle")
 
-        # Set up dialog handler before triggering the click
-        page.on("dialog", lambda d: d.accept())
-
-        # Click without waiting for navigation (dialog blocks default wait)
-        delete_button.click(no_wait_after=True)
-
-        # Wait for the highlight text to disappear (indicates delete succeeded)
-        page.wait_for_selector("text=Highlight to be deleted", state="hidden", timeout=10000)
+        # Highlight should be gone
+        assert not page.locator("text=Highlight to be deleted").is_visible()
 
         page.close()
 
-    @pytest.mark.skip(reason="Flaky in CI due to confirm dialog handling in headless mode")
     def test_delete_book(self, server, browser_context):
         """Test deleting a book."""
         page = browser_context.new_page()
@@ -455,14 +451,12 @@ class TestDeleteOperations:
         page.click('button:has-text("Add Book")')
         page.wait_for_load_state("networkidle")
 
-        # Set up dialog handler before triggering the click
-        page.on("dialog", lambda d: d.accept())
+        # Override window.confirm to always return true (avoids flaky dialog handling)
+        page.evaluate("window.confirm = () => true")
 
-        # Click without waiting for navigation (dialog blocks default wait)
-        page.click("text=Delete Book", no_wait_after=True)
-
-        # Wait for redirect to home - check for home page content
-        page.wait_for_url("**/", timeout=10000)
+        # Click delete and wait for navigation
+        page.click("text=Delete Book")
+        page.wait_for_load_state("networkidle")
 
         # Book should be gone from home page
         assert not page.locator("text=Book To Delete").is_visible()


### PR DESCRIPTION
## Summary

Fixes the flaky delete e2e tests (`test_delete_highlight`, `test_delete_book`) that were failing in CI due to JavaScript `confirm()` dialog handling issues in headless Chromium.

- Replace async dialog event handling with synchronous `window.confirm` stub
- Remove `@pytest.mark.skip` decorators from delete tests
- Simplify test assertions and navigation waits

## Research

The tests were using `page.on("dialog", lambda d: d.accept())` which is unreliable in CI because:
1. Dialog events fire asynchronously
2. No guarantee the handler is ready before the click triggers the dialog
3. CI environments have slower event processing

## Solution

Stub `window.confirm` before clicking delete buttons:
```python
page.evaluate("window.confirm = () => true")
```

This runs synchronously before any click, eliminating race conditions entirely.

## Test plan

- [x] Delete tests pass consistently when run in isolation (verified 3 runs)
- [x] Format and lint checks pass
- [x] Unit and integration tests pass (148 tests)
- [ ] CI e2e tests should now pass (verify in this PR)

Closes #30

---
Generated with [Claude Code](https://claude.com/claude-code)